### PR TITLE
Add the RE IP whitelist service

### DIFF
--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -9,3 +9,4 @@ applications:
   services:
   - publish-production-secrets
   - publish-beta-production-redis
+  - re-ip-whitelist-service

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -9,3 +9,4 @@ applications:
   services:
   - publish-staging-secrets
   - publish-beta-staging-redis
+  - re-ip-whitelist-service


### PR DESCRIPTION
This binds the service provided by RE that only allows access from whitelisted IP addresses.

We previously added this manually through `cf bind-service`, but it should also be included here in case the app to deployed again to a new space.