### PR TITLE
Use cflinuxfs3 stack

### DIFF
--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -3,6 +3,7 @@ applications:
   command: bundle exec rackup -p $PORT -o 0.0.0.0
   memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
+  stack: cflinuxfs3
   env:
     RAILS_ENV: production
     RACK_ENV: production

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -3,6 +3,7 @@ applications:
   command: bundle exec rackup -p $PORT -o 0.0.0.0
   memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
+  stack: cflinuxfs3
   env:
     RAILS_ENV: staging
     RACK_ENV: staging


### PR DESCRIPTION
cflinuxfs2 is being deprecated so we should upgrade to the latest stack version.

[Trello Card](https://trello.com/c/LnfsfS1q/875-upgrade-datagovuk-to-cflinuxfs3)